### PR TITLE
adjust time and selected hosts

### DIFF
--- a/config/grafana/dashboards/load-testing/HTTP failures.json
+++ b/config/grafana/dashboards/load-testing/HTTP failures.json
@@ -8,19 +8,28 @@
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 5,
-  "iteration": 1637829287491,
+  "iteration": 1642481719043,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
-      "datasource": "K6-InfluxDB-InfluxQL",
+      "datasource": {
+        "type": "influxdb",
+        "uid": "P4D1D31A5B69203FF"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -158,7 +167,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 30,
+  "schemaVersion": 34,
   "style": "dark",
   "tags": [
     "home-dashboard"
@@ -166,9 +175,8 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
         "current": {
-          "selected": true,
+          "selected": false,
           "text": [
             "All"
           ],
@@ -176,13 +184,13 @@
             "$__all"
           ]
         },
-        "datasource": "K6-InfluxDB-InfluxQL",
+        "datasource": {
+          "type": "influxdb",
+          "uid": "P4D1D31A5B69203FF"
+        },
         "definition": "SHOW TAG VALUES WITH KEY = \"test_id\"",
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": true,
-        "label": null,
         "multi": true,
         "name": "test_id",
         "options": [],
@@ -194,23 +202,22 @@
         "type": "query"
       },
       {
-        "allValue": null,
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
-            "https://49.12.163.186:9200"
+            "All"
           ],
           "value": [
-            "https://49.12.163.186:9200"
+            "$__all"
           ]
         },
-        "datasource": "K6-InfluxDB-InfluxQL",
+        "datasource": {
+          "type": "influxdb",
+          "uid": "P4D1D31A5B69203FF"
+        },
         "definition": "SHOW TAG VALUES WITH KEY = \"cloud_host\"",
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": true,
-        "label": null,
         "multi": true,
         "name": "host",
         "options": [],
@@ -224,12 +231,13 @@
     ]
   },
   "time": {
-    "from": "2021-11-25T08:40:40.019Z",
-    "to": "2021-11-25T09:04:00.884Z"
+    "from": "now-24h",
+    "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "HTTP failures",
   "uid": "G-gAEtpnk",
-  "version": 4
+  "version": 2,
+  "weekStart": ""
 }


### PR DESCRIPTION
currently selecting the HTTP failures dashboard jumps to `2021-11-25T08:40:40.019Z` and selects only one host this is annoying and confusing.
This change should make the dashboard show the last 24h of all hosts by default